### PR TITLE
fix: add workflow_call to call workflow from kms-core

### DIFF
--- a/.github/workflows/fhevm-e2e-tests.yml
+++ b/.github/workflows/fhevm-e2e-tests.yml
@@ -1,6 +1,48 @@
 name: fhevm E2E Tests
 
 on:
+  workflow_call:
+    inputs:
+      core_version:
+        description: "KMS Core Version"
+        required: false
+        default: "v0.11.0-rc11"
+        type: string
+      connector_version:
+        description: "Connector Version"
+        required: false
+        default: "v0.1.0-rc3"
+        type: string
+      coprocessor_version:
+        description: "Coprocessor Image Version"
+        required: false
+        default: "v0.7.0-rc6"
+        type: string
+      db_migration_version:
+        description: "Coprocessor DB Migration Image Version"
+        required: false
+        default: "v0.7.0-rc6"
+        type: string
+      host_version:
+        description: "Host Image Version"
+        required: false
+        default: "v0.7.0-rc6"
+        type: string
+      gateway_version:
+        description: "Gateway Image Version"
+        required: false
+        default: "v0.1.0-rc14"
+        type: string
+      relayer_version:
+        description: "Relayer Image Version"
+        required: false
+        default: "6573721"
+        type: string
+      tests_version:
+        description: "E2E Tests Image Version"
+        required: false
+        default: "02c6691"
+        type: string
   workflow_dispatch:
     inputs:
       core_version:


### PR DESCRIPTION
Adding workflow_call to e2e tests workflow to be able to call this workflow from other reopositories like kms-core for example.