### PR TITLE
fix: fhevm-e2e-tests, only display log on failure

### DIFF
--- a/.github/workflows/fhevm-e2e-tests.yml
+++ b/.github/workflows/fhevm-e2e-tests.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Show logs on test failure
         working-directory: fhevm
-        if: always()
+        if: failure()
         run: |
           echo "::group::Relayer Logs"
           ./fhevm-cli logs relayer


### PR DESCRIPTION
was taking more time than the test themselves